### PR TITLE
fix: Cannot access `_uploader` before initialization

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,6 @@
 		"OC": true
 	},
 	"extends": [
-		"@nextcloud"
+		"@nextcloud/eslint-config/typescript"
 	]
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import UploadPicker from './components/UploadPicker.vue'
 export { Status as UploaderStatus } from './uploader.js'
 export { Upload, Status as UploadStatus } from './upload.js'
 
-let _uploader: Uploader
+let _uploader: Uploader | null = null
 
 /**
  * Get an Uploader instance

--- a/lib/shims-vue.d.ts
+++ b/lib/shims-vue.d.ts
@@ -3,4 +3,3 @@ declare module '*.vue' {
 	const component: ReturnType<typeof defineComponent>
 	export default component
 }
-


### PR DESCRIPTION
If the variable is declared using `let` or `const` we need to initialize it explicitly before it can be accessed - even if we access it using `instanceof`.

So current *beta.9* is not usable :/