### PR TITLE
fix: `getUploader` should only be called when a new `UploadPicker` instance is created

### DIFF
--- a/lib/components/UploadPicker.vue
+++ b/lib/components/UploadPicker.vue
@@ -87,11 +87,9 @@ import Upload from 'vue-material-design-icons/Upload.vue'
 
 import { Status as UploadStatus } from '../upload.js'
 import { t } from '../utils/l10n.js'
-import { Uploader, Status } from '../uploader.js'
+import { Status } from '../uploader.js'
 import ActionIcon from './ActionIcon.vue'
 import logger from '../utils/logger.js'
-
-const uploadManager = getUploader()
 
 export default {
 	name: 'UploadPicker',
@@ -143,7 +141,7 @@ export default {
 			timeLeft: '',
 
 			newFileMenuEntries: getNewFileMenuEntries(this.context),
-			uploadManager,
+			uploadManager: getUploader(),
 		}
 	},
 
@@ -247,7 +245,7 @@ export default {
 		async onPick() {
 			const files = [...this.$refs.input.files]
 			files.forEach(file => {
-				uploadManager.upload(file.name, file)
+				this.uploadManager.upload(file.name, file)
 			})
 			this.$refs.form.reset()
 		},


### PR DESCRIPTION
Finally solved the issue with the `@nextcloud/cypress` update:

![image](https://github.com/nextcloud/nextcloud-upload/assets/1855448/7140f013-f260-4257-a27d-db1a39a712e7)