### PR TITLE
fix(i18n): Corrected plural for multi. plural languages

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -105,10 +105,13 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-msgid "Skip this file"
+msgid "Skip {count} file"
 msgid_plural "Skip {count} files"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Skip this file"
+msgstr ""
 
 msgid "Unknown size"
 msgstr ""

--- a/lib/components/ConflictPicker.vue
+++ b/lib/components/ConflictPicker.vue
@@ -194,7 +194,10 @@ export default defineComponent({
 		},
 
 		skipButtonLabel() {
-			return n('Skip this file', 'Skip {count} files', this.conflicts.length, { count: this.conflicts.length })
+			if (this.conflicts.length === 1) {
+				return t('Skip this file')
+			}
+			return n('Skip {count} file', 'Skip {count} files', this.conflicts.length, { count: this.conflicts.length })
 		},
 
 		// Select all incoming files


### PR DESCRIPTION
Reported at Transifex.
https://app.transifex.com/nextcloud/nextcloud-upload-library/translate/#de_DE/16314f783b1fbd5880d265a6aa82c3d7/488853442