### PR TITLE
feat(button): Added option to not have label on New button

### DIFF
--- a/lib/vue/components/UploadPicker.vue
+++ b/lib/vue/components/UploadPicker.vue
@@ -26,7 +26,7 @@
 
 		<NcActions v-else
 			:aria-label="buttonLabel"
-			:menu-name="noLabel ? '' : buttonLabel"
+			:menu-name="noLabel ? undefined : buttonLabel"
 			:open.sync="openedMenu"
 			:type="primary ? 'primary' : 'secondary'">
 			<template #icon>


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/server/issues/53991

## Summary
To be able to resolve https://github.com/nextcloud/server/issues/53991 regarding breakpoints in the files app I have added a prop `noLabel` on the `UploadPicker` component to disable the label on breakpoint changes.
This change is required for this PR in nextcloud/server: https://github.com/nextcloud/server/pull/54235

With label:
<img width="113" height="53" alt="image" src="https://github.com/user-attachments/assets/8b81f09d-a990-4cb2-9768-5479c11e1e78" />

Without label:
<img width="60" height="53" alt="image" src="https://github.com/user-attachments/assets/7fb43c12-e30d-4150-8319-518010d6a117" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)