### PR TITLE
fix(Uploader): Pass on customHeaders when creating chunked upload workspace

### DIFF
--- a/__tests__/utils/upload.spec.ts
+++ b/__tests__/utils/upload.spec.ts
@@ -75,6 +75,7 @@ describe('Initialize chunks upload temporary workspace', () => {
 				retries: 5,
 				retryDelay: expect.any(Function),
 			},
+      headers: {},
 		})
 	})
 

--- a/lib/uploader/uploader.ts
+++ b/lib/uploader/uploader.ts
@@ -493,7 +493,7 @@ export class Uploader {
 				logger.debug('Initializing chunked upload', { file, upload })
 
 				// Let's initialize a chunk upload
-				const tempUrl = await initChunkWorkspace(encodedDestinationFile, retries, this._isPublic)
+				const tempUrl = await initChunkWorkspace(encodedDestinationFile, retries, this._isPublic, this._customHeaders)
 				const chunksQueue: Array<Promise<void>> = []
 
 				// Generate chunks array

--- a/lib/utils/upload.ts
+++ b/lib/utils/upload.ts
@@ -116,8 +116,9 @@ export const getChunk = function(file: File, start: number, length: number): Pro
  * @param destinationFile The file name after finishing the chunked upload
  * @param retries number of retries
  * @param isPublic whether this upload is in a public share or not
+ * @param customHeaders Custom HTTP headers used when creating the workspace (e.g. X-NC-Nickname for file drops)
  */
-export const initChunkWorkspace = async function(destinationFile: string | undefined = undefined, retries: number = 5, isPublic: boolean = false): Promise<string> {
+export const initChunkWorkspace = async function(destinationFile: string | undefined = undefined, retries: number = 5, isPublic: boolean = false, customHeaders: Record<string, string> = {}): Promise<string> {
 	let chunksWorkspace: string
 	if (isPublic) {
 		chunksWorkspace = `${getBaseUrl()}/public.php/dav/uploads/${getSharingToken()}`
@@ -128,7 +129,10 @@ export const initChunkWorkspace = async function(destinationFile: string | undef
 	const hash = [...Array(16)].map(() => Math.floor(Math.random() * 16).toString(16)).join('')
 	const tempWorkspace = `web-file-upload-${hash}`
 	const url = `${chunksWorkspace}/${tempWorkspace}`
-	const headers = destinationFile ? { Destination: destinationFile } : undefined
+	const headers = customHeaders
+	if (destinationFile) {
+		headers.Destination = destinationFile
+	}
 
 	await axios.request({
 		method: 'MKCOL',


### PR DESCRIPTION
Frontend part for https://github.com/nextcloud/server/issues/55366

Without this, https://github.com/nextcloud/server/blob/50f287402a3bd1374f890f79c9504cb816751c7e/apps/files_sharing/src/public-nickname-handler.ts#L26 will not have an effect on this request and gets blocked by the backend if it is a file drop.