### PR TITLE
fix: add response to upload when assembling chunks

### DIFF
--- a/lib/uploader/uploader.ts
+++ b/lib/uploader/uploader.ts
@@ -599,6 +599,11 @@ export class Uploader {
 							upload.status = UploadStatus.CANCELLED
 							reject(new UploadCancelledError(error))
 						} else {
+							// Attach response to the upload object
+							if ((error as AxiosError)?.response) {
+								upload.response = (error as AxiosError).response as AxiosResponse
+							}
+
 							upload.status = UploadStatus.FAILED
 							reject(t('Failed to assemble the chunks together'))
 						}


### PR DESCRIPTION
Fix issue:
- on upload of 'eicar' file to Files app (with AV running), upload is correctly blocked with message 'Virus XX is detected...'. However for large files (e.g. zip archive with 'eicar' file inside) it fails on chunk assembly, but toast message contains (Unknown error during upload)

Copy from where PUT request is handled: https://github.com/nextcloud-libraries/nextcloud-upload/blob/398a3cd4c3917e8c0cb587a1c8bb66687d70fe42/lib/uploader/uploader.ts#L661-L664

Haven't tested with bundled app. though response body is the same for PUT and MOVE
<img width="247" height="160" alt="image" src="https://github.com/user-attachments/assets/4166882b-34a3-4aff-b4f0-4011498329d1" /><img width="497" height="75" alt="image" src="https://github.com/user-attachments/assets/0076c2bf-c842-40e7-89a1-1b7af64a5713" />

