### PR TITLE
Update upload icon, use outlined variant for upload-folder

### DIFF
--- a/lib/vue/components/UploadPicker.vue
+++ b/lib/vue/components/UploadPicker.vue
@@ -175,7 +175,7 @@ import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js
 import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
 
 import IconCancel from 'vue-material-design-icons/Cancel.vue'
-import IconFolderUpload from 'vue-material-design-icons/FolderUpload.vue'
+import IconFolderUpload from 'vue-material-design-icons/FolderUploadOutline.vue'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 import IconUpload from 'vue-material-design-icons/TrayArrowUp.vue'
 

--- a/lib/vue/components/UploadPicker.vue
+++ b/lib/vue/components/UploadPicker.vue
@@ -177,7 +177,7 @@ import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
 import IconCancel from 'vue-material-design-icons/Cancel.vue'
 import IconFolderUpload from 'vue-material-design-icons/FolderUpload.vue'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
-import IconUpload from 'vue-material-design-icons/Upload.vue'
+import IconUpload from 'vue-material-design-icons/TrayArrowUp.vue'
 
 import { getUploader } from '../../getUploader.ts'
 import { UploaderStatus } from '../../uploader/uploader.ts'


### PR DESCRIPTION
I don't have / have no easy way for screenshots

but if you open the menu in any instance.
* upload icon would now be https://pictogrammers.com/library/mdi/icon/tray-arrow-up/
* folder upload icons would now be: https://pictogrammers.com/library/mdi/icon/folder-upload-outline/