### PR TITLE
fix(uploader): rename deleteCustomerHeader to deleteCustomHeader

### DIFF
--- a/__tests__/uploader.spec.ts
+++ b/__tests__/uploader.spec.ts
@@ -66,7 +66,7 @@ describe('Uploader', () => {
 			const uploader = new Uploader()
 			uploader.setCustomHeader('X-NC-Nickname', 'jane')
 			expect(uploader.customHeaders).toEqual({ 'X-NC-Nickname': 'jane' })
-			uploader.deleteCustomerHeader('X-NC-Nickname')
+			uploader.deleteCustomHeader('X-NC-Nickname')
 			expect(uploader.customHeaders).toEqual({})
 		})
 
@@ -74,7 +74,7 @@ describe('Uploader', () => {
 			const uploader = new Uploader()
 			uploader.setCustomHeader('X-NC-Nickname', 'jane')
 			expect(uploader.customHeaders).toEqual({ 'X-NC-Nickname': 'jane' })
-			uploader.deleteCustomerHeader('X-NC-Nickname')
+			uploader.deleteCustomHeader('X-NC-Nickname')
 			expect(uploader.customHeaders).toEqual({})
 		})
 

--- a/lib/uploader/uploader.ts
+++ b/lib/uploader/uploader.ts
@@ -146,7 +146,7 @@ export class Uploader {
 	 * Unset a custom header
 	 * @param name The header to unset
 	 */
-	deleteCustomerHeader(name: string): void {
+	deleteCustomHeader(name: string): void {
 		delete this._customHeaders[name]
 	}
 


### PR DESCRIPTION
## Summary

Fix typo in public API method name: `deleteCustomerHeader` → `deleteCustomHeader`.

The method had an extra "r" (`Customer` instead of `Custom`), making it inconsistent with its counterpart `setCustomHeader`.
