### PR TITLE
fix: prevent file upload input from receiving keyboard tab focus

### DIFF
--- a/lib/vue/components/UploadPicker.vue
+++ b/lib/vue/components/UploadPicker.vue
@@ -150,6 +150,8 @@
 			:accept="accept?.join?.(', ')"
 			:multiple="multiple"
 			class="hidden-visually"
+			tabindex="-1"
+			aria-hidden="true"
 			data-cy-upload-picker-input
 			type="file"
 			@change="onPick">


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/server/issues/62248
## Summary
This PR updates the file upload input to prevent it from receiving keyboard focus through the `Tab` key.

## Changes
Update the class of the file input from`hidden-visually` to `hidden`.

## Reason
Using `display: none` ensures the element is excluded from the tab order, preventing users from navigating to a non-interactive control while preserving the existing file upload behavior.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
