### PR TITLE
Simplify the file conflict dialog

### DIFF
--- a/cypress/components/ConflictPicker.cy.ts
+++ b/cypress/components/ConflictPicker.cy.ts
@@ -33,18 +33,117 @@ describe('ConflictPicker rendering', { testIsolation: true }, () => {
 		})
 
 		cy.get('[data-cy-conflict-picker]').should('exist')
-		cy.get('[data-cy-conflict-picker] h2').should('have.text', '1 file conflict in Pictures')
+		cy.get('[data-cy-conflict-picker] h2').should('have.text', 'Select file to keep')
 		cy.get('[data-cy-conflict-picker-form]').should('be.visible')
 
-		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 2)
-		cy.get('[data-cy-conflict-picker-fieldset="all"]').should('exist')
+		// A single conflict needs no select all and no checkboxes
+		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 1)
+		cy.get('[data-cy-conflict-picker-fieldset="all"]').should('not.exist')
 		cy.get('[data-cy-conflict-picker-fieldset="image.jpg"]').should('exist')
+		cy.get('[data-cy-conflict-picker-form] input[type="checkbox"]').should('not.exist')
 
-		cy.get('[data-cy-conflict-picker-skip]').scrollIntoView().should('be.visible')
+		// The folder name is highlighted in the description
+		cy.get('#conflict-picker-description strong').should('have.text', 'Pictures')
+
+		// Instead both options are offered as buttons
+		cy.get('[data-cy-conflict-picker-skip]').should('not.exist')
+		cy.get('[data-cy-conflict-picker-keep-both]').scrollIntoView().should('be.visible')
 		cy.get('[data-cy-conflict-picker-submit]').should('be.visible')
 
 		// Force close and cancel
-		cy.get('[data-cy-conflict-picker-skip]').click({ force: true })
+		cy.get('[data-cy-conflict-picker-cancel]').click({ force: true })
+	})
+
+	it('Shows only the folder name, the root is called "All files"', () => {
+		const oldImage = new NcFile({
+			id: 1,
+			source: 'http://cloud.domain.com/remote.php/dav/files/user/image.jpg',
+			mime: 'image/jpeg',
+			size: 1000,
+			owner: 'user',
+			mtime: new Date('2021-01-01T00:00:00.000Z'),
+		})
+
+		cy.mount(ConflictPicker, {
+			propsData: {
+				dirname: '/Photos/Sub folder',
+				content: [oldImage],
+				conflicts: [image],
+			},
+		})
+		cy.get('#conflict-picker-description strong').should('have.text', 'Sub folder')
+
+		cy.mount(ConflictPicker, {
+			propsData: {
+				dirname: '/',
+				content: [oldImage],
+				conflicts: [image],
+			},
+		})
+		cy.get('#conflict-picker-description strong').should('have.text', 'All files')
+	})
+
+	it('Replaces the existing file', () => {
+		const oldImage = new NcFile({
+			id: 1,
+			source: 'http://cloud.domain.com/remote.php/dav/files/user/image.jpg',
+			mime: 'image/jpeg',
+			size: 1000,
+			owner: 'user',
+			mtime: new Date('2021-01-01T00:00:00.000Z'),
+		})
+
+		const onSubmit = cy.spy().as('onSubmitSpy')
+		cy.mount(ConflictPicker, {
+			propsData: {
+				dirname: 'Pictures',
+				content: [oldImage],
+				conflicts: [image],
+			},
+			listeners: {
+				submit: onSubmit,
+			},
+		})
+
+		cy.get('[data-cy-conflict-picker-submit]').click()
+
+		cy.get('@onSubmitSpy').should('have.been.calledOnce').then((onSubmit) => {
+			const results = (onSubmit as unknown as sinon.SinonSpy).firstCall.args[0]
+			expect(results.selected).to.deep.equal([image])
+			expect(results.renamed).to.have.length(0)
+		})
+	})
+
+	it('Keeps both versions by renaming the new file', () => {
+		const oldImage = new NcFile({
+			id: 1,
+			source: 'http://cloud.domain.com/remote.php/dav/files/user/image.jpg',
+			mime: 'image/jpeg',
+			size: 1000,
+			owner: 'user',
+			mtime: new Date('2021-01-01T00:00:00.000Z'),
+		})
+
+		const onSubmit = cy.spy().as('onSubmitSpy')
+		cy.mount(ConflictPicker, {
+			propsData: {
+				dirname: 'Pictures',
+				content: [oldImage],
+				conflicts: [image],
+			},
+			listeners: {
+				submit: onSubmit,
+			},
+		})
+
+		cy.get('[data-cy-conflict-picker-keep-both]').click()
+
+		cy.get('@onSubmitSpy').should('have.been.calledOnce').then((onSubmit) => {
+			const results = (onSubmit as unknown as sinon.SinonSpy).firstCall.args[0]
+			expect(results.selected).to.have.length(0)
+			expect(results.renamed).to.have.length(1)
+			expect((results.renamed[0] as File).name).to.equal('image (1).jpg')
+		})
 	})
 })
 
@@ -93,7 +192,9 @@ describe('ConflictPicker resolving', () => {
 
 		cy.get('[data-cy-conflict-picker-form]').should('be.visible')
 		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 3)
-		cy.get('[data-cy-conflict-picker-input-incoming="all"] input').check({ force: true })
+
+		// The new files are preselected, so we can continue right away
+		cy.get('[data-cy-conflict-picker-input-incoming="all"] input').should('be.checked')
 		cy.get('[data-cy-conflict-picker-submit]').click()
 
 		cy.get('@onSubmitSpy').should('have.been.calledOnce').then((onSubmit) => {
@@ -138,6 +239,9 @@ describe('ConflictPicker resolving', () => {
 
 		cy.get('[data-cy-conflict-picker-form]').should('be.visible')
 		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 3)
+
+		// Deselect the preselected new files and keep the existing ones instead
+		cy.get('[data-cy-conflict-picker-input-incoming="all"] input').uncheck({ force: true })
 		cy.get('[data-cy-conflict-picker-input-existing="all"] input').check({ force: true })
 		cy.get('[data-cy-conflict-picker-submit]').click()
 
@@ -183,7 +287,8 @@ describe('ConflictPicker resolving', () => {
 
 		cy.get('[data-cy-conflict-picker-form]').should('be.visible')
 		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 3)
-		cy.get('[data-cy-conflict-picker-input-incoming="image1.jpg"] input').check({ force: true })
+		// Keep the new image1 (preselected) but the existing image2
+		cy.get('[data-cy-conflict-picker-input-incoming="image2.jpg"] input').uncheck({ force: true })
 		cy.get('[data-cy-conflict-picker-input-existing="image2.jpg"] input').check({ force: true })
 		cy.get('[data-cy-conflict-picker-submit]').click()
 
@@ -230,7 +335,7 @@ describe('ConflictPicker resolving', () => {
 
 		cy.get('[data-cy-conflict-picker-form]').should('be.visible')
 		cy.get('[data-cy-conflict-picker-fieldset]').should('have.length', 3)
-		cy.get('[data-cy-conflict-picker-input-incoming="all"] input').check({ force: true })
+		// The new files are preselected, additionally keep the existing ones
 		cy.get('[data-cy-conflict-picker-input-existing="all"] input').check({ force: true })
 		cy.get('[data-cy-conflict-picker-submit]').click()
 

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -11,16 +11,6 @@ msgstr ""
 msgid "\"{segment}\" is not allowed inside a file or folder name."
 msgstr ""
 
-msgid "{count} file conflict"
-msgid_plural "{count} files conflict"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "{count} file conflict in {dirname}"
-msgid_plural "{count} file conflicts in {dirname}"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "{seconds} seconds left"
 msgid_plural "{seconds} seconds left"
 msgstr[0] ""
@@ -31,6 +21,12 @@ msgid "{time} left"
 msgstr ""
 
 msgid "a few seconds left"
+msgstr ""
+
+msgid "All files"
+msgstr ""
+
+msgid "An item with the same name already exists in {dirname}."
 msgstr ""
 
 msgid "assembling"
@@ -54,6 +50,12 @@ msgstr ""
 msgid "estimating time left"
 msgstr ""
 
+msgid "Existing files"
+msgstr ""
+
+msgid "Existing files and folders will be deleted if not selected. If both are chosen, they will be renamed."
+msgstr ""
+
 msgid "Existing version"
 msgstr ""
 
@@ -66,10 +68,13 @@ msgstr ""
 msgid "Filenames must not end with \"{segment}\"."
 msgstr ""
 
-msgid "If you select both versions, the incoming file will have a number added to its name."
+msgid "Invalid filename"
 msgstr ""
 
-msgid "Invalid filename"
+msgid "Items with the same name already exist in {dirname}, select which to keep."
+msgstr ""
+
+msgid "Keep both"
 msgstr ""
 
 msgid "Last modified date unknown"
@@ -81,25 +86,28 @@ msgstr ""
 msgid "New filename"
 msgstr ""
 
+msgid "New files"
+msgstr ""
+
 msgid "New version"
 msgstr ""
 
 msgid "paused"
 msgstr ""
 
-msgid "Preview image"
+msgid "Rename"
 msgstr ""
 
-msgid "Rename"
+msgid "Replace"
 msgstr ""
 
 msgid "Select all checkboxes"
 msgstr ""
 
-msgid "Select all existing files"
+msgid "Select file to keep"
 msgstr ""
 
-msgid "Select all new files"
+msgid "Select files to keep"
 msgstr ""
 
 msgid "Skip"
@@ -109,9 +117,6 @@ msgid "Skip {count} file"
 msgid_plural "Skip {count} files"
 msgstr[0] ""
 msgstr[1] ""
-
-msgid "Skip this file"
-msgstr ""
 
 msgid "Unknown size"
 msgstr ""
@@ -140,13 +145,10 @@ msgstr ""
 msgid "Upload progress"
 msgstr ""
 
-msgid "When an incoming folder is selected, any conflicting files within it will also be overwritten."
+msgid "When a new folder is selected, any conflicting files within it will also be overwritten."
 msgstr ""
 
-msgid "When an incoming folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed."
-msgstr ""
-
-msgid "Which files do you want to keep?"
+msgid "When a new folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed."
 msgstr ""
 
 msgid "You can either rename the file, skip this file or cancel the whole operation."

--- a/lib/dialogs/components/ConflictPicker.vue
+++ b/lib/dialogs/components/ConflictPicker.vue
@@ -15,13 +15,15 @@
 		<div class="conflict-picker__header">
 			<!-- Description -->
 			<p id="conflict-picker-description" class="conflict-picker__description">
-				{{ t('Which files do you want to keep?') }}<br>
-				{{ t('If you select both versions, the incoming file will have a number added to its name.') }}<br>
+				{{ descriptionParts.before }}<strong>{{ folderName }}</strong>{{ descriptionParts.after }}<br>
+				<template v-if="!isSingle">
+					{{ t('Existing files and folders will be deleted if not selected. If both are chosen, they will be renamed.') }}<br>
+				</template>
 				<template v-if="recursiveUpload">
-					{{ t('When an incoming folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed.') }}
+					{{ t('When a new folder is selected, the content is written into the existing folder and a recursive conflict resolution is performed.') }}
 				</template>
 				<template v-else>
-					{{ t('When an incoming folder is selected, any conflicting files within it will also be overwritten.') }}
+					{{ t('When a new folder is selected, any conflicting files within it will also be overwritten.') }}
 				</template>
 			</p>
 		</div>
@@ -32,20 +34,21 @@
 			aria-labelledby="conflict-picker-description"
 			data-cy-conflict-picker-form
 			@submit.prevent.stop="onSubmit">
-			<!-- Select all checkboxes -->
-			<fieldset class="conflict-picker__all" data-cy-conflict-picker-fieldset="all">
+			<!-- Column headings, the select all checkboxes are only useful with multiple files -->
+			<fieldset v-if="!isSingle" class="conflict-picker__all" data-cy-conflict-picker-fieldset="all">
 				<legend class="hidden-visually">
 					{{ t('Select all checkboxes') }}
 				</legend>
-				<NcCheckboxRadioSwitch v-bind="selectAllNewBind"
-					data-cy-conflict-picker-input-incoming="all"
-					@update:checked="onSelectAllNew">
-					{{ t('Select all new files') }}
-				</NcCheckboxRadioSwitch>
 				<NcCheckboxRadioSwitch v-bind="selectAllOldBind"
 					data-cy-conflict-picker-input-existing="all"
 					@update:checked="onSelectAllOld">
-					{{ t('Select all existing files') }}
+					{{ t('Existing files') }}
+				</NcCheckboxRadioSwitch>
+				<span />
+				<NcCheckboxRadioSwitch v-bind="selectAllNewBind"
+					data-cy-conflict-picker-input-incoming="all"
+					@update:checked="onSelectAllNew">
+					{{ t('New files') }}
 				</NcCheckboxRadioSwitch>
 			</fieldset>
 
@@ -55,6 +58,7 @@
 				:key="node.fileid"
 				:incoming="conflicts[index]"
 				:existing="files[index]"
+				:is-single="isSingle"
 				:new-selected.sync="newSelected"
 				:old-selected.sync="oldSelected" />
 		</form>
@@ -67,35 +71,48 @@
 				data-cy-conflict-picker-cancel
 				type="tertiary"
 				@click="onCancel">
-				<template #icon>
-					<Close :size="20" />
-				</template>
 				{{ t('Cancel') }}
 			</NcButton>
 
 			<!-- Align right -->
 			<span class="dialog__actions-separator" />
 
-			<NcButton :aria-label="skipButtonLabel"
-				data-cy-conflict-picker-skip
-				@click="onSkip">
-				<template #icon>
-					<Close :size="20" />
-				</template>
-				{{ skipButtonLabel }}
-			</NcButton>
-			<NcButton :aria-label="t('Continue')"
-				:class="{ 'button-vue--disabled': !isEnoughSelected}"
-				:title="isEnoughSelected ? '' : blockedTitle"
-				data-cy-conflict-picker-submit
-				native-type="submit"
-				type="primary"
-				@click.stop.prevent="onSubmit">
-				<template #icon>
-					<ArrowRight :size="20" />
-				</template>
-				{{ t('Continue') }}
-			</NcButton>
+			<!-- Single file: keep both versions or replace the existing one -->
+			<template v-if="isSingle">
+				<NcButton :aria-label="t('Keep both')"
+					data-cy-conflict-picker-keep-both
+					type="secondary"
+					@click="onKeepBoth">
+					{{ t('Keep both') }}
+				</NcButton>
+				<NcButton :aria-label="t('Replace')"
+					data-cy-conflict-picker-submit
+					type="primary"
+					@click="onReplace">
+					{{ t('Replace') }}
+				</NcButton>
+			</template>
+
+			<!-- Multiple files: skip them all or continue with the selection -->
+			<template v-else>
+				<NcButton :aria-label="skipButtonLabel"
+					data-cy-conflict-picker-skip
+					@click="onSkip">
+					{{ skipButtonLabel }}
+				</NcButton>
+				<NcButton :aria-label="t('Continue')"
+					:class="{ 'button-vue--disabled': !isEnoughSelected}"
+					:title="isEnoughSelected ? '' : blockedTitle"
+					data-cy-conflict-picker-submit
+					native-type="submit"
+					type="primary"
+					@click.stop.prevent="onSubmit">
+					<template #icon>
+						<ArrowRight :size="20" />
+					</template>
+					{{ t('Continue') }}
+				</NcButton>
+			</template>
 		</template>
 	</NcDialog>
 </template>
@@ -108,9 +125,9 @@ import type { ConflictResolutionResult } from '../openConflictPicker.ts'
 import { defineComponent } from 'vue'
 import { showError } from '@nextcloud/dialogs'
 import { getUniqueName } from '@nextcloud/files'
+import { basename } from '@nextcloud/paths'
 
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
-import Close from 'vue-material-design-icons/Close.vue'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -127,7 +144,6 @@ export default defineComponent({
 
 	components: {
 		ArrowRight,
-		Close,
 		NcButton,
 		NcCheckboxRadioSwitch,
 		NcDialog,
@@ -135,7 +151,7 @@ export default defineComponent({
 	},
 
 	props: {
-		/** Directory/context file name */
+		/** Directory with the conflicts, its name is shown in the description */
 		dirname: {
 			type: String,
 			default: '',
@@ -184,19 +200,35 @@ export default defineComponent({
 
 	computed: {
 		name() {
-			if (this?.dirname?.trim?.() !== '') {
-				return n('{count} file conflict in {dirname}', '{count} file conflicts in {dirname}', this.conflicts.length, {
-					count: this.conflicts.length,
-					dirname: this.dirname,
-				})
-			}
-			return n('{count} file conflict', '{count} files conflict', this.conflicts.length, { count: this.conflicts.length })
+			return this.isSingle
+				? t('Select file to keep')
+				: t('Select files to keep')
 		},
 
+		/**
+		 * A single conflict does not need checkboxes,
+		 * "Keep both" and "Replace" cover both options.
+		 */
+		isSingle(): boolean {
+			return this.conflicts.length === 1
+		},
+
+		// Only the folder name, the root folder is called "All files" in the Files app
+		folderName(): string {
+			return basename(this.dirname ?? '') || t('All files')
+		},
+
+		// Split on the placeholder so the folder name can be shown in bold
+		descriptionParts(): { before: string, after: string } {
+			const message = this.isSingle
+				? t('An item with the same name already exists in {dirname}.')
+				: t('Items with the same name already exist in {dirname}, select which to keep.')
+			const [before, after = ''] = message.split('{dirname}')
+			return { before, after }
+		},
+
+		// Only shown for multiple conflicts, a single one is handled by "Keep both"/"Replace"
 		skipButtonLabel() {
-			if (this.conflicts.length === 1) {
-				return t('Skip this file')
-			}
 			return n('Skip {count} file', 'Skip {count} files', this.conflicts.length, { count: this.conflicts.length })
 		},
 
@@ -276,6 +308,9 @@ export default defineComponent({
 			throw error
 		}
 
+		// Preselect the new files so the user can continue right away
+		this.newSelected = this.conflicts
+
 		// Successful initialisation
 		logger.debug('ConflictPicker initialised', { files: this.files, conflicts: this.conflicts, content: this.content })
 	},
@@ -293,6 +328,24 @@ export default defineComponent({
 				selected: [],
 				renamed: [],
 			} as ConflictResolutionResult<File>)
+		},
+
+		/**
+		 * Single file: only keep the new file, the existing one is overwritten.
+		 */
+		onReplace() {
+			this.newSelected = this.conflicts
+			this.oldSelected = []
+			this.onSubmit()
+		},
+
+		/**
+		 * Single file: keep both, so the new file is uploaded under a new name.
+		 */
+		onKeepBoth() {
+			this.newSelected = this.conflicts
+			this.oldSelected = this.files
+			this.onSubmit()
 		},
 
 		onSubmit() {
@@ -405,6 +458,8 @@ export default defineComponent({
 .conflict-picker {
 	--margin: 36px;
 	--secondary-margin: 18px;
+	// shared width of the middle arrow column, so headings and entries line up
+	--arrow-column: 44px;
 
 	&__header {
 		position: sticky;
@@ -425,16 +480,20 @@ export default defineComponent({
 
 	fieldset {
 		display: grid;
+		align-items: center;
 		width: 100%;
 		margin-top: calc(var(--secondary-margin) * 1.5);
 		padding-bottom: var(--secondary-margin);
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr var(--arrow-column) 1fr;
 
 		:deep(legend) {
 			display: flex;
 			align-items: center;
+			grid-column: 1 / -1;
 			width: 100%;
 			margin-bottom: calc(var(--secondary-margin) / 2);
+			// The legend names the file both versions belong to
+			font-weight: bold;
 		}
 
 		&.conflict-picker__all {
@@ -466,6 +525,8 @@ export default defineComponent({
 	:deep(.dialog__actions) {
 		width: auto;
 		margin-inline: 12px;
+		// Match the 24px the buttons have on the sides
+		margin-block-end: calc(var(--default-grid-baseline) * 6);
 		span.dialog__actions-separator {
 			margin-left: auto;
 		}
@@ -486,6 +547,11 @@ export default defineComponent({
 			&.conflict-picker__all {
 				position: static;
 			}
+		}
+
+		// The versions are stacked, so an arrow pointing right makes no sense
+		:deep(.node-picker__arrow) {
+			display: none;
 		}
 	}
 }

--- a/lib/dialogs/components/NodePickerCard.vue
+++ b/lib/dialogs/components/NodePickerCard.vue
@@ -1,0 +1,179 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<span class="node-picker">
+		<!-- Icon or preview -->
+		<template v-if="!showPreview">
+			<FolderSvg v-if="isFolder" class="node-picker__icon" :size="48" />
+			<FileSvg v-else class="node-picker__icon" :size="48" />
+		</template>
+		<img v-else
+			class="node-picker__preview"
+			:src="preview"
+			alt=""
+			loading="lazy"
+			@error="previewFailed = true">
+
+		<!-- Description -->
+		<span class="node-picker__desc">
+			<NcDateTime v-if="mtime"
+				:timestamp="mtime"
+				:relative-time="false"
+				:format="{ timeStyle: 'short', dateStyle: 'medium' }"
+				class="node-picker__mtime"
+				:class="{ 'node-picker__value--bold': boldDate }" />
+			<span v-else class="node-picker__mtime">
+				{{ t('Last modified date unknown') }}
+			</span>
+			<span class="node-picker__size" :class="{ 'node-picker__value--bold': boldSize }">
+				{{ formattedSize }}
+			</span>
+
+			<!-- The column heading labels this visually, keep it for screen readers -->
+			<span class="hidden-visually">{{ label }}</span>
+		</span>
+	</span>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { formatFileSize } from '@nextcloud/files'
+
+import FileSvg from 'vue-material-design-icons/File.vue'
+import FolderSvg from 'vue-material-design-icons/Folder.vue'
+import NcDateTime from '@nextcloud/vue/dist/Components/NcDateTime.js'
+
+import { t } from '../../utils/l10n.ts'
+
+export default defineComponent({
+	name: 'NodePickerCard',
+
+	components: {
+		FileSvg,
+		FolderSvg,
+		NcDateTime,
+	},
+
+	props: {
+		/** Preview url, if any */
+		preview: {
+			type: String,
+			default: null,
+		},
+
+		/** Last modified date, if known */
+		mtime: {
+			type: Date,
+			default: null,
+		},
+
+		/** Size in bytes, if known */
+		size: {
+			type: Number,
+			default: null,
+		},
+
+		/** Use the folder icon as fallback */
+		isFolder: {
+			type: Boolean,
+			default: false,
+		},
+
+		/** Label for screen readers ("Existing version"/"New version") */
+		label: {
+			type: String,
+			required: true,
+		},
+
+		/** Highlight the date as it is the more recent one */
+		boldDate: {
+			type: Boolean,
+			default: false,
+		},
+
+		/** Highlight the size as it is the bigger one */
+		boldSize: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	data() {
+		return {
+			// Previews can 404, fall back to the icon instead of a broken image
+			previewFailed: false,
+		}
+	},
+
+	computed: {
+		showPreview(): boolean {
+			return !!this.preview && !this.previewFailed
+		},
+
+		formattedSize(): string {
+			if (this.size) {
+				return formatFileSize(this.size, true)
+			}
+			return t('Unknown size')
+		},
+	},
+
+	watch: {
+		preview() {
+			this.previewFailed = false
+		},
+	},
+
+	methods: {
+		t,
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+$height: 64px;
+
+.node-picker {
+	display: flex;
+	align-items: center;
+	height: $height;
+
+	&__icon, &__preview {
+		height: $height;
+		width: $height;
+		margin: 0 var(--secondary-margin);
+		display: block;
+		flex: 0 0 $height;
+	}
+
+	&__icon {
+		color: var(--color-text-maxcontrast);
+
+		&.folder-icon {
+			color: var(--color-primary-element);
+		}
+	}
+
+	&__preview {
+		overflow: hidden;
+		border-radius: calc(var(--border-radius) * 2);
+		object-fit: cover;
+	}
+
+	&__desc {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		span {
+			white-space: nowrap;
+		}
+	}
+
+	// Highlight whichever value differs, to ease comparison
+	&__value--bold {
+		font-weight: bold;
+	}
+}
+</style>

--- a/lib/dialogs/components/NodesPicker.vue
+++ b/lib/dialogs/components/NodesPicker.vue
@@ -6,71 +6,54 @@
 	<fieldset class="node-picker__wrapper" :data-cy-conflict-picker-fieldset="existing.basename">
 		<legend>{{ existing.basename }}</legend>
 
-		<!-- Incoming file -->
-		<NcCheckboxRadioSwitch :checked="isChecked(incoming, newSelected)"
-			:required="!isEnoughSelected"
-			:data-cy-conflict-picker-input-incoming="existing.basename"
-			@update:checked="onUpdateIncomingChecked">
-			<span class="node-picker node-picker--incoming">
-				<!-- Icon or preview -->
-				<template v-if="!incomingPreview">
-					<FolderSvg v-if="isFolder(incoming)" class="node-picker__icon" :size="48" />
-					<FileSvg v-else class="node-picker__icon" :size="48" />
-				</template>
-				<img v-else
-					class="node-picker__preview"
-					:src="incomingPreview"
-					:alt="t('Preview image')"
-					loading="lazy">
-
-				<!-- Description -->
-				<span class="node-picker__desc">
-					<span class="node-picker__name">{{ t('New version') }}</span>
-					<NcDateTime v-if="incomingLastModified"
-						:timestamp="incomingLastModified"
-						:relative-time="false"
-						:format="{ timeStyle: 'short', dateStyle: 'medium' }"
-						class="node-picker__mtime" />
-					<span v-else class="node-picker__mtime">
-						{{ t('Last modified date unknown') }}
-					</span>
-					<span class="node-picker__size">{{ incomingSize }}</span>
-				</span>
-			</span>
-		</NcCheckboxRadioSwitch>
-
 		<!-- Existing file -->
-		<NcCheckboxRadioSwitch :checked="isChecked(existing, oldSelected)"
+		<NcCheckboxRadioSwitch v-if="!isSingle"
+			:checked="isChecked(existing, oldSelected)"
 			:required="!isEnoughSelected"
 			:data-cy-conflict-picker-input-existing="existing.basename"
 			@update:checked="onUpdateExistingChecked">
-			<span class="node-picker node-picker--existing">
-				<!-- Icon or preview -->
-				<template v-if="!existingPreview">
-					<FolderSvg v-if="isFolder(existing)" class="node-picker__icon" :size="48" />
-					<FileSvg v-else class="node-picker__icon" :size="48" />
-				</template>
-				<img v-else
-					class="node-picker__preview"
-					:src="existingPreview"
-					:alt="t('Preview image')"
-					loading="lazy">
-
-				<!-- Description -->
-				<span class="node-picker__desc">
-					<span class="node-picker__name">{{ t('Existing version') }}</span>
-					<NcDateTime v-if="existingLastModified"
-						:timestamp="existingLastModified"
-						:relative-time="false"
-						:format="{ timeStyle: 'short', dateStyle: 'medium' }"
-						class="node-picker__mtime" />
-					<span v-else class="node-picker__mtime">
-						{{ t('Last modified date unknown') }}
-					</span>
-					<span class="node-picker__size">{{ size(existing) }}</span>
-				</span>
-			</span>
+			<NodePickerCard :preview="existingPreview"
+				:mtime="existingLastModified"
+				:size="existingSize"
+				:is-folder="isFolder(existing)"
+				:label="t('Existing version')"
+				:bold-date="existingNewer"
+				:bold-size="existingLarger" />
 		</NcCheckboxRadioSwitch>
+		<NodePickerCard v-else
+			:preview="existingPreview"
+			:mtime="existingLastModified"
+			:size="existingSize"
+			:is-folder="isFolder(existing)"
+			:label="t('Existing version')"
+			:bold-date="existingNewer"
+			:bold-size="existingLarger" />
+
+		<!-- Points from the existing to the new version -->
+		<ArrowRight class="node-picker__arrow" :size="20" />
+
+		<!-- Incoming file -->
+		<NcCheckboxRadioSwitch v-if="!isSingle"
+			:checked="isChecked(incoming, newSelected)"
+			:required="!isEnoughSelected"
+			:data-cy-conflict-picker-input-incoming="existing.basename"
+			@update:checked="onUpdateIncomingChecked">
+			<NodePickerCard :preview="incomingPreview"
+				:mtime="incomingLastModified"
+				:size="incomingSize"
+				:is-folder="isFolder(incoming)"
+				:label="t('New version')"
+				:bold-date="incomingNewer"
+				:bold-size="incomingLarger" />
+		</NcCheckboxRadioSwitch>
+		<NodePickerCard v-else
+			:preview="incomingPreview"
+			:mtime="incomingLastModified"
+			:size="incomingSize"
+			:is-folder="isFolder(incoming)"
+			:label="t('New version')"
+			:bold-date="incomingNewer"
+			:bold-size="incomingLarger" />
 	</fieldset>
 </template>
 
@@ -79,16 +62,15 @@ import type { Node } from '@nextcloud/files'
 import type { PropType } from 'vue'
 
 import { defineComponent } from 'vue'
-import { formatFileSize, FileType } from '@nextcloud/files'
+import { FileType } from '@nextcloud/files'
 import { generateUrl } from '@nextcloud/router'
 
-import FileSvg from 'vue-material-design-icons/File.vue'
-import FolderSvg from 'vue-material-design-icons/Folder.vue'
-import NcDateTime from '@nextcloud/vue/dist/Components/NcDateTime.js'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 
 import { isFileSystemEntry, isFileSystemFileEntry } from '../../utils/filesystem.ts'
 import { t } from '../../utils/l10n.ts'
+import NodePickerCard from './NodePickerCard.vue'
 
 const PREVIEW_SIZE = 64
 
@@ -96,10 +78,9 @@ export default defineComponent({
 	name: 'NodesPicker',
 
 	components: {
-		FileSvg,
-		FolderSvg,
+		ArrowRight,
 		NcCheckboxRadioSwitch,
-		NcDateTime,
+		NodePickerCard,
 	},
 
 	props: {
@@ -118,6 +99,15 @@ export default defineComponent({
 		oldSelected: {
 			type: Array as PropType<Node[]>,
 			required: true,
+		},
+
+		/**
+		 * Single file mode: show both versions without checkboxes.
+		 * The parent offers "Keep both" and "Replace" buttons instead.
+		 */
+		isSingle: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -155,11 +145,8 @@ export default defineComponent({
 			return this.lastModified(this.incomingFile)
 		},
 
-		incomingSize(): string {
-			if (!this.incomingFile) {
-				return t('Unknown size')
-			}
-			return this.size(this.incomingFile)
+		incomingSize(): number | null {
+			return this.incomingFile?.size ?? null
 		},
 
 		existingPreview() {
@@ -168,6 +155,24 @@ export default defineComponent({
 
 		existingLastModified() {
 			return this.lastModified(this.existing)
+		},
+
+		existingSize(): number | null {
+			return this.existing.size ?? null
+		},
+
+		// Highlight the more recent date and the bigger size to ease comparison
+		incomingNewer(): boolean {
+			return this.isBigger(this.incomingLastModified?.getTime(), this.existingLastModified?.getTime())
+		},
+		existingNewer(): boolean {
+			return this.isBigger(this.existingLastModified?.getTime(), this.incomingLastModified?.getTime())
+		},
+		incomingLarger(): boolean {
+			return this.isBigger(this.incomingSize, this.existingSize)
+		},
+		existingLarger(): boolean {
+			return this.isBigger(this.existingSize, this.incomingSize)
 		},
 	},
 
@@ -194,17 +199,23 @@ export default defineComponent({
 	},
 
 	methods: {
+		/**
+		 * Both values need to be known, otherwise there is nothing to compare.
+		 * @param value the value to highlight if it is the bigger one
+		 * @param other the value to compare against
+		 */
+		isBigger(value?: number | null, other?: number | null): boolean {
+			if (!value || !other) {
+				return false
+			}
+			return value > other
+		},
+
 		lastModified(node: File|Node): Date | null {
 			const lastModified = node instanceof File
 				? new Date(node.lastModified)
 				: node.mtime
 			return lastModified ?? null
-		},
-		size(node: File|Node): string {
-			if (node.size) {
-				return formatFileSize(node.size, true)
-			}
-			return t('Unknown size')
 		},
 		previewUrl(node: File|Node) {
 			if (node instanceof File) {
@@ -301,8 +312,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-$height: 64px;
-
 .node-picker__wrapper {
 	// last fieldset does not have a border
 	&:not(:last-of-type) {
@@ -310,39 +319,13 @@ $height: 64px;
 	}
 }
 
-.node-picker {
-	display: flex;
-	align-items: center;
-	height: $height;
+.node-picker__arrow {
+	justify-self: center;
+	color: var(--color-text-maxcontrast);
+}
 
-	&__icon, &__preview {
-		height: $height;
-		width: $height;
-		margin: 0 var(--secondary-margin);
-		display: block;
-		flex: 0 0 $height;
-	}
-
-	&__icon {
-		color: var(--color-text-maxcontrast);
-
-		&.folder-icon {
-			color: var(--color-primary-element);
-		}
-	}
-
-	&__preview {
-		overflow: hidden;
-		border-radius: calc(var(--border-radius) * 2);
-		object-fit: cover;
-	}
-
-	&__desc {
-		display: flex;
-		flex-direction: column;
-		span {
-			white-space: nowrap;
-		}
-	}
+// The arrow points from the existing to the new version
+[dir="rtl"] .node-picker__arrow {
+	transform: scaleX(-1);
 }
 </style>


### PR DESCRIPTION
Same as https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/2540

Our current file conflict dialog (when you upload the same file again) immediately jumps into a very complex "pick files" view.

Based on a mockup by @kra-mo and some discussions.

The improvements:
- "Existing version" has been moved to the left and "New version" to the right. This is swapped from the previous layout as that was confusing – new things are usually on the right.
- The flow for 1 file was simplified by removing the checkboxes altogether, and just going for buttons "Keep both" and "Replace".
- For multiple files, the newer files are all preselected by default. That way people can click "Continue" directly.
- The wording is simplified
- To more easily compare what’s new or what changed between existing and new, whichever date is newer is bolded, and whichever size is larger is bolded.
- A little arrow inbetween each of the versions pointing right from the existing file to the new file helps with visual clarity.
- The icons of the cancel and skip buttons were removed to reduce visual noise.

We could probably simplify the wording even more for the multiple files case, but this PR is also quite big already. :) 


Before|After
-|-
<img width="1000" height="600" alt="before-single" src="https://github.com/user-attachments/assets/9bd31191-c736-44b0-b5f2-942de63c0e47" />|<img width="1000" height="600" alt="single" src="https://github.com/user-attachments/assets/94299129-0a5e-4b96-a8bd-be7bf0df73c9" />
<img width="1000" height="600" alt="before-multiple" src="https://github.com/user-attachments/assets/f9e3d3ca-113f-47ca-89cb-d28ddeed0915" />|<img width="1000" height="600" alt="multiple" src="https://github.com/user-attachments/assets/a5626928-bedf-4dfc-82eb-d68642791a54" />

### Mockup by @kra-mo for reference

<img width="716" height="328" alt="20260723_122436" src="https://github.com/user-attachments/assets/3bf9893a-6e10-40fb-a729-ab54a2e5ed69" />




## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI